### PR TITLE
feat: add brazilian portuguese language

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,11 +1,12 @@
 import { createI18n } from 'vue-i18n';
 import de from './locales/de.json';
 import en from './locales/en.json';
+import br from './locales/pt-br.json';
 
 export type MessageSchema = typeof en;
 
 const browserLocale = navigator.language.slice(0, 2).toLowerCase();
-const messages: Record<string, MessageSchema> = { en, de } as const;
+const messages: Record<string, MessageSchema> = { en, de, br } as const;
 
 export const availableLocales = Object.keys(messages);
 export const initialLocale = availableLocales.includes(browserLocale) ? browserLocale : 'en';

--- a/src/i18n/locales/pt-br.json
+++ b/src/i18n/locales/pt-br.json
@@ -1,0 +1,144 @@
+{
+  "_numberFormats": {
+    "currency": {
+      "currency": "USD",
+      "minimumFractionDigits": 0,
+      "style": "currency"
+    },
+    "percent": {
+      "maximumFractionDigits": 0,
+      "style": "percent"
+    }
+  },
+  "navigation": {
+    "tools": {
+      "tools": "Ferramentas",
+      "changePassword": {
+        "change": "Mudar a senha",
+        "current": "Senha atual",
+        "new": "Nova senha",
+        "invalid": "Senha atual inválida.",
+        "unknownError": "Houve um erro, por favor tente novamente mais tarde."
+      },
+      "copyPaste": {
+        "copy": "Copie os dados de {year}",
+        "paste": "Copie os dados de {from} into {to}",
+        "confirm": "Você tem certeza de que quer copiar os dados de {from} para {to}?"
+      },
+      "demo": {
+        "loadDemoData": "Carregar exemplo"
+      },
+      "deleteYear": {
+        "delete": "Remover {year}",
+        "confirm": "Você tem certeza de que quer remover {year}?"
+      },
+      "export": {
+        "export": "Exportar para arquivo json"
+      },
+      "import": {
+        "import": "Importar de arquivo json",
+        "what": {
+          "google": "Arquivo de finança anual do Google Sheets",
+          "ocular": "Um arquivo exportado anteriormente",
+          "title": "O que você gostaria de importar?"
+        },
+        "ocular": {
+          "pickFile": "Selecione o seu arquivo .json para importar",
+          "import": "Importar dados do Ocular"
+        },
+        "google": {
+          "import": "Importar dados do Google Sheets",
+          "pickFile": "Selecione o seu arquivo .csv para importar",
+          "expenses": "Expenses.csv",
+          "income": "Income.csv"
+        }
+      },
+      "privacyMode": {
+        "disable": "Mudar para o modo público",
+        "enable": "Mudar para o modo privado"
+      }
+    },
+    "language": {
+      "switch": "Alterar o idioma"
+    },
+    "info": {
+      "about": "Sobre o Ocular",
+      "github": "Confira este projeto no {link}!",
+      "madeWithLove": "Feito com ❤️ pelo Simon",
+      "meta": "{version} / {date} / {sha}"
+    },
+    "currency": {
+      "change": "Altere a moeda a ser usada"
+    },
+    "theme": {
+      "change": "Altere a cor do tema"
+    },
+    "year": {
+      "change": "Mude para outro ano"
+    },
+    "auth": {
+      "welcomeBack": "Olá de novo!",
+      "signIn": "Logar",
+      "username": "Usuário",
+      "password": "Senha",
+      "loginFailed": "Falha ao logar, usuário e/ou senha inválidos."
+    },
+    "admin": {
+      "settings": "Configurações de Administrador",
+      "createUser": "Criar usuário",
+      "username": "Usuário",
+      "password": "Senha",
+      "admin": "Admin",
+      "conflict": "Um usuário com este nome já existe.",
+      "error": "Algo deu errado, tente novamente mais tarde.",
+      "deleteUserConfirmation": "Você tem certeza de que quer deletar este usuário?",
+      "manageUsers": "Manage users",
+      "noUsersFound": "Nenhum usuário encontrado..."
+    }
+  },
+  "shared": {
+    "addGroup": "Adicionar Grupo",
+    "append": "Mover \"{from}\" para depois de \"{to}\"",
+    "average": "Média",
+    "move": "Mover \"{from}\"",
+    "moveInto": "Mover \"{from}\" para \"{to}\"",
+    "prepend": "Mover \"{from}\" para antes de \"{to}\"",
+    "fillRow": "Completar esta linha",
+    "fillRowToRight": "Completar para a direita",
+    "total": "Total",
+    "totals": "Totais",
+    "placeholder": "Comece preenchendo as abas de Receita / Despesas! :)"
+  },
+  "page": {
+    "income": {
+      "title": "Receita"
+    },
+    "expenses": {
+      "title": "Despesas"
+    },
+    "dashboard": {
+      "title": "Painel",
+      "tables": "Tabelas",
+      "income": "Receita",
+      "incomeTrend": "Tendência de Receita",
+      "allTime": "Visão geral dos anos",
+      "allTimeFromTo": "Visão geral de {from} até {to}",
+      "expenses": "Despesas",
+      "expensesTrend": "Tendência de Despesas",
+      "endingBalance": "Balanço Final",
+      "header": "Orçamento anual para {year}",
+      "remainingBalance": "Balanço restante para {year}",
+      "netSavings": "Receita líquida",
+      "yearInThePast": "Ano anterior",
+      "yearInTheFuture": "Ano seguinte",
+      "yearEnding": "Esse ano está chegando ao fim...",
+      "yoyIncomeGrowth": "Aumento da Receita ao Ano",
+      "yoyExpenseGrowth": "Aumento de Despesas ao Ano",
+      "allTimeIncome": "Receita pelos Anos",
+      "allTimeExpenses": "Despesas pelos Anos",
+      "allTimeSavings": "Economias pelos Anos",
+      "downloadAsPNG": "Baixar como PNG",
+      "downloadAsSVG": "Baixar como SVG"
+    }
+  }
+}


### PR DESCRIPTION
Pull request from `ptocular` branch to Ocular's `main` branch to provide Portuguese (Brazil) as a language option.

Both [Contributing Guidelines](https://github.com/simonwep/ocular/blob/e99e8f1847f3d034ac99b073d4568d72ca4091e2/.github/CONTRIBUTING.md) and ["turkish" pull request](https://github.com/simonwep/ocular/pull/40#pullrequestreview-2051315183) have been followed to the extent of all guidance provided, except by `test:ci` routine which did not respond to move `build` as a PR. Please advise if additional steps are required.